### PR TITLE
Fix require is not defined error

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,6 +1,6 @@
-require("@nomicfoundation/hardhat-toolbox");
+import "@nomicfoundation/hardhat-toolbox";
 
 /** @type import('hardhat/config').HardhatUserConfig */
-module.exports = {
+export default {
   solidity: "0.8.28",
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "pharmatrace",
   "version": "1.0.0",
+  "type": "module",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Convert Hardhat configuration to ES module syntax and declare project type to resolve `require is not defined` error.

The project was encountering a `ReferenceError: require is not defined in ES module scope` because `hardhat.config.js` used CommonJS syntax while the Node.js environment was treating `.js` files as ES modules. This PR updates the config to ES module syntax and explicitly sets `"type": "module"` in `package.json` to ensure compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-fa932f23-137e-4a30-bfae-2006e7b9c8cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fa932f23-137e-4a30-bfae-2006e7b9c8cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

